### PR TITLE
✈ Update: January 2021 Feature Pack Update

### DIFF
--- a/Buildersoft.Andy.X.sln
+++ b/Buildersoft.Andy.X.sln
@@ -23,7 +23,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Buildersoft.Andy.X.Utilitie
 		{89AF1B22-CFA0-44BD-84D9-ABCA8AE9E729} = {89AF1B22-CFA0-44BD-84D9-ABCA8AE9E729}
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Buildersoft.Andy.X.FileConfig", "src\Buildersoft.Andy.X.FileConfig\Buildersoft.Andy.X.FileConfig.csproj", "{C8509DF5-12AE-4E36-9463-6101E30387FF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Buildersoft.Andy.X.IO", "src\Buildersoft.Andy.X.FileConfig\Buildersoft.Andy.X.IO.csproj", "{C8509DF5-12AE-4E36-9463-6101E30387FF}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Buildersoft.Andy.X.Router", "src\Buildersoft.Andy.X.Router\Buildersoft.Andy.X.Router.csproj", "{D5D2ED04-159E-4576-A200-801B24C298E8}"
 EndProject

--- a/src/Buildersoft.Andy.X.Data.Model/Book.cs
+++ b/src/Buildersoft.Andy.X.Data.Model/Book.cs
@@ -13,6 +13,9 @@ namespace Buildersoft.Andy.X.Data.Model
         public string InstanceName { get; set; }
         public ConcurrentDictionary<string, Message> Messages { get; set; }
         public ConcurrentDictionary<string, Reader> Readers { get; set; }
+
+        public Schema Schema { get; set; }
+
         public DataTypes DataType { get; set; }
         public DateTime CreatedDate { get; set; }
         public DateTime ModifiedDate { get; set; }
@@ -22,6 +25,9 @@ namespace Buildersoft.Andy.X.Data.Model
             Id = Guid.NewGuid();
             Messages = new ConcurrentDictionary<string, Message>();
             Readers = new ConcurrentDictionary<string, Reader>();
+
+            Schema = new Schema();
+
             CreatedDate = DateTime.Now;
             ModifiedDate = DateTime.Now;
         }
@@ -29,6 +35,27 @@ namespace Buildersoft.Andy.X.Data.Model
         public void SetId(Guid id)
         {
             Id = id;
+        }
+    }
+
+    public class Schema
+    {
+        public string Name { get; set; }
+
+        // Check if the schema should be validated before messages are transmitting via Andy.
+        public bool SchemaValidationStatus { get; set; }
+
+        public string SchemaRawData { get; set; }
+        public int Version { get; set; }
+        public DateTime CreatedDate { get; set; }
+        public DateTime ModifiedDate { get; set; }
+
+        public Schema()
+        {
+            SchemaValidationStatus = false;
+            Version = 1;
+            CreatedDate = DateTime.Now;
+            ModifiedDate = DateTime.Now;
         }
     }
 }

--- a/src/Buildersoft.Andy.X.Data.Model/Buildersoft.Andy.X.Data.Model.csproj
+++ b/src/Buildersoft.Andy.X.Data.Model/Buildersoft.Andy.X.Data.Model.csproj
@@ -5,7 +5,7 @@
     <Authors>Buildersoft</Authors>
     <Company>Buildersoft</Company>
     <Product>Buildersoft Andy</Product>
-    <Version>1.0.20.74</Version>
+    <Version>1.1.20.75</Version>
     <Description>Buildersoft Andy X is a distributed messaging system. This system will empower developers to move into Event Driven Systems. Andy X is a multi-tenant system.</Description>
     <Copyright>Copyright © Buildersoft 2020</Copyright>
   </PropertyGroup>

--- a/src/Buildersoft.Andy.X.Data.Model/Buildersoft.Andy.X.Data.Model.csproj
+++ b/src/Buildersoft.Andy.X.Data.Model/Buildersoft.Andy.X.Data.Model.csproj
@@ -7,7 +7,7 @@
     <Product>Buildersoft Andy</Product>
     <Version>1.1.20.75</Version>
     <Description>Buildersoft Andy X is a distributed messaging system. This system will empower developers to move into Event Driven Systems. Andy X is a multi-tenant system.</Description>
-    <Copyright>Copyright © Buildersoft 2020</Copyright>
+    <Copyright>Copyright © Buildersoft 2021</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Buildersoft.Andy.X.Data.Model/DataStorages/BookDetail.cs
+++ b/src/Buildersoft.Andy.X.Data.Model/DataStorages/BookDetail.cs
@@ -14,6 +14,6 @@ namespace Buildersoft.Andy.X.Data.Model.DataStorages
         public string BookName { get; set; }
         public DataTypes DataType { get; set; }
 
-        // TODO... Add properties for this Book
+        public Schema Schema { get; set; }
     }
 }

--- a/src/Buildersoft.Andy.X.FileConfig/Buildersoft.Andy.X.IO.csproj
+++ b/src/Buildersoft.Andy.X.FileConfig/Buildersoft.Andy.X.IO.csproj
@@ -5,7 +5,7 @@
     <Authors>Buildersoft</Authors>
     <Company>Buildersoft</Company>
     <Product>Buildersoft Andy</Product>
-    <Version>1.0.20.74</Version>
+    <Version>1.1.20.75</Version>
     <Description>Buildersoft Andy X is a distributed messaging system. This system will empower developers to move into Event Driven Systems. Andy X is a multi-tenant system.</Description>
     <Copyright>Copyright © Buildersoft 2020</Copyright>
   </PropertyGroup>

--- a/src/Buildersoft.Andy.X.FileConfig/Buildersoft.Andy.X.IO.csproj
+++ b/src/Buildersoft.Andy.X.FileConfig/Buildersoft.Andy.X.IO.csproj
@@ -7,7 +7,7 @@
     <Product>Buildersoft Andy</Product>
     <Version>1.1.20.75</Version>
     <Description>Buildersoft Andy X is a distributed messaging system. This system will empower developers to move into Event Driven Systems. Andy X is a multi-tenant system.</Description>
-    <Copyright>Copyright © Buildersoft 2020</Copyright>
+    <Copyright>Copyright © Buildersoft 2021</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Buildersoft.Andy.X.FileConfig/Files/ConfigFile.cs
+++ b/src/Buildersoft.Andy.X.FileConfig/Files/ConfigFile.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
-namespace Buildersoft.Andy.X.FileConfig.Files
+namespace Buildersoft.Andy.X.IO.Files
 {
     public static class ConfigFile
     {

--- a/src/Buildersoft.Andy.X.Logic/Buildersoft.Andy.X.Logic.csproj
+++ b/src/Buildersoft.Andy.X.Logic/Buildersoft.Andy.X.Logic.csproj
@@ -5,7 +5,7 @@
     <Authors>Buildersoft</Authors>
     <Company>Buildersoft</Company>
     <Product>Buildersoft Andy</Product>
-    <Version>1.0.20.74</Version>
+    <Version>1.1.20.75</Version>
     <Description>Buildersoft Andy X is a distributed messaging system. This system will empower developers to move into Event Driven Systems. Andy X is a multi-tenant system.</Description>
     <Copyright>Copyright © Buildersoft 2020</Copyright>
   </PropertyGroup>

--- a/src/Buildersoft.Andy.X.Logic/Buildersoft.Andy.X.Logic.csproj
+++ b/src/Buildersoft.Andy.X.Logic/Buildersoft.Andy.X.Logic.csproj
@@ -7,7 +7,7 @@
     <Product>Buildersoft Andy</Product>
     <Version>1.1.20.75</Version>
     <Description>Buildersoft Andy X is a distributed messaging system. This system will empower developers to move into Event Driven Systems. Andy X is a multi-tenant system.</Description>
-    <Copyright>Copyright © Buildersoft 2020</Copyright>
+    <Copyright>Copyright © Buildersoft 2021</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Buildersoft.Andy.X.Logic/Repositories/Books/BookLogic.cs
+++ b/src/Buildersoft.Andy.X.Logic/Repositories/Books/BookLogic.cs
@@ -28,20 +28,21 @@ namespace Buildersoft.Andy.X.Logic.Books
             {
                 InstanceName = name,
                 DataType = dataTypes,
-            };
-
-            if (schemaRawData != "")
-            {
-                book.Schema = new Schema()
+                Schema = new Schema()
                 {
                     Name = $"{name}-schema",
                     SchemaRawData = schemaRawData,
-                    SchemaValidationStatus = true
-                };
+                }
+            };
+
+            if (schemaRawData != "" && schemaRawData != "{}")
+            {
+                book.Schema.SchemaValidationStatus = true;
             }
 
             if (_bookRepository.Add(book))
                 return book;
+
             return null;
         }
 

--- a/src/Buildersoft.Andy.X.Logic/Repositories/Interfaces/Books/IBookLogic.cs
+++ b/src/Buildersoft.Andy.X.Logic/Repositories/Interfaces/Books/IBookLogic.cs
@@ -1,14 +1,19 @@
-﻿using Buildersoft.Andy.X.Data.Model.Enums;
-using System;
+﻿using Buildersoft.Andy.X.Data.Model;
+using Buildersoft.Andy.X.Data.Model.Enums;
 using System.Collections.Generic;
-using System.Text;
+using System.Threading.Tasks;
 
 namespace Buildersoft.Andy.X.Logic.Interfaces.Books
 {
     public interface IBookLogic
     {
-        Data.Model.Book CreateBook(string name, DataTypes dataTypes);
-        Data.Model.Book GetBook(string name);
-        List<Data.Model.Book> GetAllBooks();
+        Book CreateBook(string name, DataTypes dataTypes, string schemaRawData);
+        Book GetBook(string name);
+        List<Book> GetAllBooks();
+        Schema GetBookSchema(string bookName);
+        Book UpdateBookSchema(string bookName, string jsonSchema, bool isSchemaValid);
+
+        bool IfSchemaIsDifferent(string bookName, string jsonSchema);
+        Task<bool> IsSchemaValidAsync(string bookName, string message);
     }
 }

--- a/src/Buildersoft.Andy.X.Router/Buildersoft.Andy.X.Router.csproj
+++ b/src/Buildersoft.Andy.X.Router/Buildersoft.Andy.X.Router.csproj
@@ -7,7 +7,7 @@
     <Product>Buildersoft Andy</Product>
     <Version>1.1.20.75</Version>
     <Description>Buildersoft Andy X is a distributed messaging system. This system will empower developers to move into Event Driven Systems. Andy X is a multi-tenant system.</Description>
-    <Copyright>Copyright © Buildersoft 2020</Copyright>
+    <Copyright>Copyright © Buildersoft 2021</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Buildersoft.Andy.X.Router/Buildersoft.Andy.X.Router.csproj
+++ b/src/Buildersoft.Andy.X.Router/Buildersoft.Andy.X.Router.csproj
@@ -5,7 +5,7 @@
     <Authors>Buildersoft</Authors>
     <Company>Buildersoft</Company>
     <Product>Buildersoft Andy</Product>
-    <Version>1.0.20.74</Version>
+    <Version>1.1.20.75</Version>
     <Description>Buildersoft Andy X is a distributed messaging system. This system will empower developers to move into Event Driven Systems. Andy X is a multi-tenant system.</Description>
     <Copyright>Copyright © Buildersoft 2020</Copyright>
   </PropertyGroup>
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Buildersoft.Andy.X.Data.Model\Buildersoft.Andy.X.Data.Model.csproj" />
-    <ProjectReference Include="..\Buildersoft.Andy.X.FileConfig\Buildersoft.Andy.X.FileConfig.csproj" />
+    <ProjectReference Include="..\Buildersoft.Andy.X.FileConfig\Buildersoft.Andy.X.IO.csproj" />
     <ProjectReference Include="..\Buildersoft.Andy.X.Logic\Buildersoft.Andy.X.Logic.csproj" />
     <ProjectReference Include="..\Buildersoft.Andy.X.Utilities\Buildersoft.Andy.X.Utilities.csproj" />
   </ItemGroup>

--- a/src/Buildersoft.Andy.X.Router/Hubs/DataStorages/DataStorageHub.cs
+++ b/src/Buildersoft.Andy.X.Router/Hubs/DataStorages/DataStorageHub.cs
@@ -2,7 +2,7 @@
 using Buildersoft.Andy.X.Data.Model.DataStorages;
 using Buildersoft.Andy.X.Data.Model.DataStorages.Events;
 using Buildersoft.Andy.X.Data.Model.Router.DataStorages;
-using Buildersoft.Andy.X.FileConfig.Files;
+using Buildersoft.Andy.X.IO.Files;
 using Buildersoft.Andy.X.Logic;
 using Buildersoft.Andy.X.Router.Hubs.Interfaces.DataStorages;
 using Buildersoft.Andy.X.Router.Repositories;

--- a/src/Buildersoft.Andy.X.Router/Hubs/Interfaces/DataStorages/IDataStorageHub.cs
+++ b/src/Buildersoft.Andy.X.Router/Hubs/Interfaces/DataStorages/IDataStorageHub.cs
@@ -40,5 +40,7 @@ namespace Buildersoft.Andy.X.Router.Hubs.Interfaces.DataStorages
         Task BookRead(BookDetail book);
         Task BookUpdated(BookDetail book);
         Task BookDeleted(BookDetail book);
+
+        Task BookSchemaUpdated(BookDetail book);
     }
 }

--- a/src/Buildersoft.Andy.X.Router/Hubs/Readers/ReaderHub.cs
+++ b/src/Buildersoft.Andy.X.Router/Hubs/Readers/ReaderHub.cs
@@ -1,6 +1,7 @@
 ﻿using Buildersoft.Andy.X.Data.Model.Enums;
 using Buildersoft.Andy.X.Data.Model.Readers.Events;
 using Buildersoft.Andy.X.Logic;
+using Buildersoft.Andy.X.Logic.Books;
 using Buildersoft.Andy.X.Logic.Readers;
 using Buildersoft.Andy.X.Router.Hubs.Interfaces.Readers;
 using Buildersoft.Andy.X.Router.Repositories;
@@ -76,6 +77,14 @@ namespace Buildersoft.Andy.X.Router.Hubs.Readers
 
             //connect only if tenant, product and component states are true.
 
+            // Check how to send schema in header of Reader Request to check if the schemas are the same.
+            //var bookLogic = new BookLogic(
+            //     _storageMemoryRepository.GetBooks(reader.Tenant, reader.Product, reader.Component));
+
+            //if (await bookLogic.IsSchemaValidAsync(reader.Book, msg.ToString()) != true)
+            //    return BadRequest("INVALID_SCHEMA");
+
+
             _readerRepository.Add(clientConnectionId, reader);
 
             _ = _readerService.StoreReaderAsync(new Data.Model.DataStorages.ReaderDetail()
@@ -111,7 +120,6 @@ namespace Buildersoft.Andy.X.Router.Hubs.Readers
                 ReaderType = readerToDelete.ReaderType,
                 ReaderName = readerToDelete.ReaderName
             });
-
             _readerRepository.Remove(Context.ConnectionId);
 
             return base.OnDisconnectedAsync(exception);

--- a/src/Buildersoft.Andy.X.Router/Services/DataStorages/BookService.cs
+++ b/src/Buildersoft.Andy.X.Router/Services/DataStorages/BookService.cs
@@ -30,5 +30,13 @@ namespace Buildersoft.Andy.X.Router.Services.DataStorages
                 await _hub.Clients.Client(storage.Key).BookCreated(book);
             }
         }
+
+        public async Task UpdateBookSchemaAsync(BookDetail book)
+        {
+            foreach (var storage in _dataStorageRepository.GetAll())
+            {
+                await _hub.Clients.Client(storage.Key).BookSchemaUpdated(book);
+            }
+        }
     }
 }

--- a/src/Buildersoft.Andy.X.Utilities/Buildersoft.Andy.X.Utilities.csproj
+++ b/src/Buildersoft.Andy.X.Utilities/Buildersoft.Andy.X.Utilities.csproj
@@ -7,7 +7,7 @@
     <Product>Buildersoft Andy</Product>
     <Version>1.1.20.75</Version>
     <Description>Buildersoft Andy X is a distributed messaging system. This system will empower developers to move into Event Driven Systems. Andy X is a multi-tenant system.</Description>
-    <Copyright>Copyright © Buildersoft 2020</Copyright>
+    <Copyright>Copyright © Buildersoft 2021</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Buildersoft.Andy.X.Utilities/Buildersoft.Andy.X.Utilities.csproj
+++ b/src/Buildersoft.Andy.X.Utilities/Buildersoft.Andy.X.Utilities.csproj
@@ -5,7 +5,7 @@
     <Authors>Buildersoft</Authors>
     <Company>Buildersoft</Company>
     <Product>Buildersoft Andy</Product>
-    <Version>1.0.20.74</Version>
+    <Version>1.1.20.75</Version>
     <Description>Buildersoft Andy X is a distributed messaging system. This system will empower developers to move into Event Driven Systems. Andy X is a multi-tenant system.</Description>
     <Copyright>Copyright © Buildersoft 2020</Copyright>
   </PropertyGroup>
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.8.0" />
+    <PackageReference Include="NJsonSchema" Version="10.3.3" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
   </ItemGroup>
 

--- a/src/Buildersoft.Andy.X.Utilities/Extensions/JsonSchemaValidation.cs
+++ b/src/Buildersoft.Andy.X.Utilities/Extensions/JsonSchemaValidation.cs
@@ -1,0 +1,33 @@
+﻿using NJsonSchema;
+using System.Threading.Tasks;
+
+namespace Buildersoft.Andy.X.Utilities.Extensions
+{
+    public static class JsonSchemaValidation
+    {
+        public static string ToJsonSchema<T>(this T t) where T : class
+        {
+            return JsonSchema.FromType<T>().ToJson();
+        }
+
+        public static bool IsSchemaValid<T>(this string jsonRawData) where T : class
+        {
+            var jsonSchema = JsonSchema.FromType<T>();
+            var errors = jsonSchema.Validate(jsonRawData);
+            if (errors.Count > 0)
+                return false;
+
+            return true;
+        }
+
+        public async static Task<bool> IsSchemaValidAsync(this string jsonRawData, string jsonSchemaData)
+        {
+            var jsonSchema = await JsonSchema.FromJsonAsync(jsonSchemaData);
+            var errors = jsonSchema.Validate(jsonRawData);
+            if (errors.Count > 0)
+                return false;
+
+            return true;
+        }
+    }
+}

--- a/src/Buildersoft.Andy.X/Buildersoft.Andy.X.csproj
+++ b/src/Buildersoft.Andy.X/Buildersoft.Andy.X.csproj
@@ -7,7 +7,7 @@
     <Product>Buildersoft Andy</Product>
     <Version>1.1.20.75</Version>
     <Description>Buildersoft Andy X is a distributed messaging system. This system will empower developers to move into Event Driven Systems. Andy X is a multi-tenant system.</Description>
-    <Copyright>Copyright © Buildersoft 2020</Copyright>
+    <Copyright>Copyright © Buildersoft 2021</Copyright>
     <UserSecretsId>773f5b84-4c7d-47d6-919e-a898f66308a9</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>

--- a/src/Buildersoft.Andy.X/Buildersoft.Andy.X.csproj
+++ b/src/Buildersoft.Andy.X/Buildersoft.Andy.X.csproj
@@ -5,7 +5,7 @@
     <Authors>Buildersoft</Authors>
     <Company>Buildersoft</Company>
     <Product>Buildersoft Andy</Product>
-    <Version>1.0.20.74</Version>
+    <Version>1.1.20.75</Version>
     <Description>Buildersoft Andy X is a distributed messaging system. This system will empower developers to move into Event Driven Systems. Andy X is a multi-tenant system.</Description>
     <Copyright>Copyright © Buildersoft 2020</Copyright>
     <UserSecretsId>773f5b84-4c7d-47d6-919e-a898f66308a9</UserSecretsId>
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Buildersoft.Andy.X.Data.Model\Buildersoft.Andy.X.Data.Model.csproj" />
-    <ProjectReference Include="..\Buildersoft.Andy.X.FileConfig\Buildersoft.Andy.X.FileConfig.csproj" />
+    <ProjectReference Include="..\Buildersoft.Andy.X.FileConfig\Buildersoft.Andy.X.IO.csproj" />
     <ProjectReference Include="..\Buildersoft.Andy.X.Logic\Buildersoft.Andy.X.Logic.csproj" />
     <ProjectReference Include="..\Buildersoft.Andy.X.Router\Buildersoft.Andy.X.Router.csproj" />
     <ProjectReference Include="..\Buildersoft.Andy.X.Utilities\Buildersoft.Andy.X.Utilities.csproj" />

--- a/src/Buildersoft.Andy.X/Controllers/BooksController.cs
+++ b/src/Buildersoft.Andy.X/Controllers/BooksController.cs
@@ -51,8 +51,20 @@ namespace Buildersoft.Andy.X.Controllers
             return NotFound("BOOK_NOT_FOUND");
         }
 
+        [HttpGet("tenants/{tenantName}/products/{productName}/components/{componentName}/books/{bookName}/schema")]
+        public ActionResult<Schema> GetBookSchema(string tenantName, string productName, string componentName, string bookName)
+        {
+            _bookLogic = new BookLogic(
+               _memoryRepository.GetBooks(tenantName, productName, componentName));
+            Schema schema = _bookLogic.GetBookSchema(bookName);
+            if (schema != null)
+                return Ok(schema);
+
+            return NotFound("BOOK_AND_SCHEMA_NOT_FOUND");
+        }
+
         [HttpPost("tenants/{tenantName}/products/{productName}/components/{componentName}/books/{bookName}")]
-        public async Task<ActionResult<Book>> CreateBook(string tenantName, string productName, string componentName, string bookName)
+        public async Task<ActionResult<Book>> CreateBook(string tenantName, string productName, string componentName, string bookName, [FromBody] Object schemaRawData)
         {
             _bookLogic = new BookLogic(
                 _memoryRepository.GetBooks(tenantName, productName, componentName));
@@ -60,7 +72,7 @@ namespace Buildersoft.Andy.X.Controllers
             if (_bookLogic.GetBook(bookName) != null)
                 return BadRequest("BOOK_EXISTS");
 
-            Book book = _bookLogic.CreateBook(bookName, DataTypes.Json);
+            Book book = _bookLogic.CreateBook(bookName, DataTypes.Json, schemaRawData.ToString());
             if (book != null)
             {
                 await _bookService.CreateBookAsync(new Data.Model.DataStorages.BookDetail()
@@ -70,7 +82,8 @@ namespace Buildersoft.Andy.X.Controllers
                     ProductName = productName,
                     ComponentName = componentName,
                     BookName = bookName,
-                    DataType = DataTypes.Json
+                    DataType = DataTypes.Json,
+                    Schema = book.Schema,
                 });
 
                 return Ok(book);
@@ -80,15 +93,19 @@ namespace Buildersoft.Andy.X.Controllers
         }
 
         [HttpPost("tenants/{tenantName}/products/{productName}/components/{componentName}/books/{bookName}/type/{dataType}")]
-        public async Task<ActionResult<Book>> CreateBook(string tenantName, string productName, string componentName, string bookName, string dataType)
+        public async Task<ActionResult<Book>> CreateBook(string tenantName, string productName, string componentName, string bookName, string dataType, [FromBody] Object schemaRawData)
         {
+            // TODO: Refactor the code, remove duplicate code.
+
             _bookLogic = new BookLogic(
                 _memoryRepository.GetBooks(tenantName, productName, componentName));
 
             if (_bookLogic.GetBook(bookName) != null)
                 return BadRequest("BOOK_EXISTS");
+
             DataTypes _dataType = (DataTypes)Enum.Parse(typeof(DataTypes), dataType);
-            Book book = _bookLogic.CreateBook(bookName, _dataType);
+
+            Book book = _bookLogic.CreateBook(bookName, _dataType, schemaRawData.ToString());
             if (book != null)
             {
                 await _bookService.CreateBookAsync(new Data.Model.DataStorages.BookDetail()
@@ -98,13 +115,41 @@ namespace Buildersoft.Andy.X.Controllers
                     ProductName = productName,
                     ComponentName = componentName,
                     BookName = bookName,
-                    DataType = _dataType
+                    DataType = _dataType,
+                    Schema = book.Schema
                 });
 
                 return Ok(book);
             }
 
             return BadRequest("BOOK_NOT_CREATED");
+        }
+
+        [HttpPost("tenants/{tenantName}/products/{productName}/components/{componentName}/books/{bookName}/schema")]
+        public async Task<ActionResult<Book>> UpdateSchema(string tenantName, string productName, string componentName, string bookName, [FromQuery] bool isSchemaValid, [FromBody] Object schemaRaw)
+        {
+            _bookLogic = new BookLogic(
+               _memoryRepository.GetBooks(tenantName, productName, componentName));
+            Book book = _bookLogic.GetBook(bookName);
+
+            if (_bookLogic.IfSchemaIsDifferent(bookName, schemaRaw.ToString()) == true)
+            {
+                // Update
+                book = _bookLogic.UpdateBookSchema(bookName, schemaRaw.ToString(), isSchemaValid);
+
+                await _bookService.UpdateBookSchemaAsync(new Data.Model.DataStorages.BookDetail()
+                {
+                    BookId = book.Id,
+                    TenantName = tenantName,
+                    ProductName = productName,
+                    ComponentName = componentName,
+                    BookName = bookName,
+                    DataType = book.DataType,
+                    Schema = book.Schema
+                });
+            }
+
+            return Ok(book);
         }
     }
 }

--- a/src/Buildersoft.Andy.X/Controllers/MessagesController.cs
+++ b/src/Buildersoft.Andy.X/Controllers/MessagesController.cs
@@ -57,7 +57,11 @@ namespace Buildersoft.Andy.X.Controllers
         public async Task<ActionResult<Guid>> CreateMessageAsJsonFromApi(string tenantName, string productName, string componentName, string bookName, [FromBody] object msg)
         {
             Guid generatedMessageId = Guid.NewGuid();
+            var bookLogic = new BookLogic(
+                _memoryRepository.GetBooks(tenantName, productName, componentName));
 
+            if (await bookLogic.IsSchemaValidAsync(bookName, msg.ToString()) != true)
+                return BadRequest("INVALID_SCHEMA");
 
             //Store the message into DataStorage
             await _messageService.StoreMessageAsync(new Data.Model.DataStorages.MessageDetail()
@@ -90,6 +94,12 @@ namespace Buildersoft.Andy.X.Controllers
             Guid generatedMessageId = msgId;
             if (generatedMessageId == Guid.Empty)
                 generatedMessageId = Guid.NewGuid();
+
+            var bookLogic = new BookLogic(
+                _memoryRepository.GetBooks(tenantName, productName, componentName));
+
+            if (await bookLogic.IsSchemaValidAsync(bookName, msg.ToString()) != true)
+                return BadRequest("INVALID_SCHEMA");
 
             //Store the message into DataStorage
             await _messageService.StoreMessageAsync(new Data.Model.DataStorages.MessageDetail()

--- a/src/Buildersoft.Andy.X/Controllers/StorageController.cs
+++ b/src/Buildersoft.Andy.X/Controllers/StorageController.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Buildersoft.Andy.X.Data.Model;
 using Buildersoft.Andy.X.Data.Model.DataStorages;
 using Buildersoft.Andy.X.Data.Model.Router.DataStorages;
-using Buildersoft.Andy.X.FileConfig.Files;
+using Buildersoft.Andy.X.IO.Files;
 using Buildersoft.Andy.X.Logic;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;

--- a/src/Buildersoft.Andy.X/Extensions/DI/Swagger.cs
+++ b/src/Buildersoft.Andy.X/Extensions/DI/Swagger.cs
@@ -16,7 +16,7 @@ namespace Buildersoft.Andy.X.Extensions.DI
             {
                 c.SwaggerDoc("v1", new OpenApiInfo
                 {
-                    Version = "v1",
+                    Version = "v1.1",
                     Title = "Buildersoft Andy X",
                     Description = "Welcome to Buildersoft Andy X, the first distributed message streaming platform designed for .NET"
                 });


### PR DESCRIPTION
Message Schemas are especially important on communication between two different services. Schemas as enabled feature on Andy X, Messages can be transmitted between two and more services only if their schema is valid with the book schema. This feature can be active and in-active for different books.

We have developed schemas in the core of Andy X, using Andy X Toolkit developers can update the book schema if the schema changes. All schemas are versioned and stored on Andy X DataStorage. Below is an example on a schema that is in used to validate messages that will be transmitted via Andy X.
E.g., If a service is in used and the schema that that service uses changes, the service cannot submit new messages or receive, but schema cannot be changed if a reader in that book is active. This feature will prevent corrupting running applications.


    {
        "$schema": "http://json-schema.org/draft-04/schema#",
        "title": "ExampleModel",
        "type": "object",
        "additionalProperties": false,
        "properties": {
            "Message": {
                "type": [
                    "null",
                    "string"
                ]
            }
        }
    }
If a service that will have to update the schema will try to start while other services are consuming messages for the same book, this service will not start. This feature is enabling more control and stability between services that communicates in asynchronous way.

Schema is a brand-new feature on Andy X, we would love to get feedback and suggestions from you! You can give feedback via email or GitHub.